### PR TITLE
Add special handling for Twitter's `/i/web/status/{id}` URLs

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -13,6 +13,6 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - name: golangci-lint
-        uses: golangci/golangci-lint-action@v2
+        uses: golangci/golangci-lint-action@v3
         with:
-          version: v1.39.0
+          version: v1.50.1

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -14,8 +14,9 @@ jobs:
     strategy:
       matrix:
         go-version:
-        - '1.16'
-        - '1.15'
+        - '1.19'
+        - '1.18'
+        - '1.17'
 
     steps:
     - name: setup
@@ -50,4 +51,4 @@ jobs:
       uses: codecov/codecov-action@v1
       with:
         file: ./coverage.out
-      if: ${{ matrix.go-version == '1.16' }}
+      if: ${{ matrix.go-version == '1.19' }}

--- a/canonicalizer_test.go
+++ b/canonicalizer_test.go
@@ -14,7 +14,7 @@ type testCase struct {
 func TestCanonicalize(t *testing.T) {
 	t.Parallel()
 
-	var testCases = []testCase{
+	testCases := []testCase{
 		// Normalization
 		{
 			name:     "escaping spaces in various places",

--- a/tweet_fetcher_test.go
+++ b/tweet_fetcher_test.go
@@ -36,6 +36,10 @@ func TestMatchTweetURL(t *testing.T) {
 
 		// query parameters ignored
 		{"https://twitter.com/thresholderbot/status/1341197329550995456?utm_whatever=foo", "https://twitter.com/thresholderbot/status/1341197329550995456", true},
+
+		// /i/web/status URLs matched
+		{"https://twitter.com/i/web/status/1595160647238844416", "https://twitter.com/__urlresolver__/status/1595160647238844416", true},
+		{"https://twitter.com/i/web/status/1595160647238844416?foo=bar", "https://twitter.com/__urlresolver__/status/1595160647238844416", true},
 	}
 	for _, tc := range testCases {
 		t.Run(tc.given, func(t *testing.T) {

--- a/urlresolver.go
+++ b/urlresolver.go
@@ -243,5 +243,4 @@ func (r *redirectRecorder) checkRedirect(req *http.Request, via []*http.Request)
 		return http.ErrUseLastResponse
 	}
 	return nil
-
 }


### PR DESCRIPTION
These URLs show up fairly often in tweets, but I can't find documentation on why that is.  My assumption is that they indicate tweets using more than 140 characters and/or with embedded media.

The special Twitter oembed endpoint we use when resolving a URL pointing to a tweet cannot handle these special URLs directly, but it turns out the oembed endpoint only cares about the ID of the tweet, which these special URLs do include.

So, we can handle them by translating them into "dummy" Tweet URLs before handing them off to the oembed endpoint.