### PR TITLE
Fix twitter oembed requests

### DIFF
--- a/fakebrowser/fakebrowser.go
+++ b/fakebrowser/fakebrowser.go
@@ -10,10 +10,10 @@ import (
 // Not very sportsmanlike, but basically effective at letting us fetch page
 // titles.
 var DefaultHeaders = map[string]string{
-	"Accept":          "text/html,application/xhtml+xml,application/xml;q=0.9,image/webp,*/*;q=0.8",
+	"Accept":          "text/html,application/xhtml+xml,application/xml;q=0.9,image/avif,image/webp,*/*;q=0.8",
 	"Accept-Language": "en-US,en;q=0.5",
 	"Referer":         "https://duckduckgo.com/",
-	"User-Agent":      "Mozilla/5.0 (Macintosh; Intel Mac OS X 10.15; rv:87.0) Gecko/20100101 Firefox/87.0",
+	"User-Agent":      "Mozilla/5.0 (Macintosh; Intel Mac OS X 10.15; rv:109.0) Gecko/20100101 Firefox/113.0",
 }
 
 // Transport is an http.RoundTripper implementation that injects a set of

--- a/tweet_fetcher.go
+++ b/tweet_fetcher.go
@@ -61,7 +61,7 @@ func (f *oembedTweetFetcher) Fetch(ctx context.Context, tweetURL string) (tweetD
 		return tweetData{}, err
 	}
 	if resp.StatusCode != http.StatusOK {
-		return tweetData{}, fmt.Errorf("twitter oembed error: %d", resp.StatusCode)
+		return tweetData{}, fmt.Errorf("twitter oembed error: GET %s: HTTP %d", oembedURL, resp.StatusCode)
 	}
 
 	buf := f.pool.Get()

--- a/tweet_fetcher_test.go
+++ b/tweet_fetcher_test.go
@@ -154,7 +154,7 @@ func TestFetch(t *testing.T) {
 					w.WriteHeader(http.StatusInternalServerError)
 				}
 			},
-			wantErr: errors.New("twitter oembed error: 500"),
+			wantErr: errors.New("twitter oembed error:"),
 		},
 		"bad JSON": {
 			handler: func(t *testing.T) http.HandlerFunc {

--- a/urlresolver.go
+++ b/urlresolver.go
@@ -62,7 +62,7 @@ func New(transport http.RoundTripper, timeout time.Duration) *Resolver {
 		singleflightGroup: &singleflight.Group{},
 		timeout:           timeout,
 		transport:         transport,
-		tweetFetcher:      newTweetFetcher(transport, timeout, pool),
+		tweetFetcher:      newTweetFetcher(http.DefaultTransport, timeout, pool),
 	}
 }
 


### PR DESCRIPTION
For unknown reasons, resolving titles for tweet URLs using [Twitter's `https://publish.twitter.com/oembed` oembed API endpoint](https://developer.twitter.com/en/docs/twitter-for-websites/oembed-api#item1) started failing with `404` errors sometime on 2023-05-23.  Here's the view from [Thresholderbot](https://thresholderbot.com)'s perspective:

<img width="1210" alt="image" src="https://github.com/mccutchen/urlresolver/assets/57938/3d3e272c-2832-4602-9602-e8b64c5d5a17">

urlresolver's "tweet fetcher" functionality uses the same underlying http transport as normal url resolution, which means that in practice it's generally using the transport provided by [our `fakebrowser` package](https://github.com/mccutchen/urlresolver/tree/main/fakebrowser), which attempts to masquerade requests as if they're coming from a real browser.

First I wondered whether something about the combination of headers being sent in was causing Twitter, but updating them to the latest values matching my current version of Firefox made no difference.

Next I tried making the same request with the same headers via `curl`, and it worked fine.  I can see no difference in the request headers between go (using [httputil.DumpRequest](https://pkg.go.dev/net/http/httputil#DumpRequest), which does have some limitations) and `curl -v`.

Out of desperation, I tried using the default transport instead, it it seems to Just Work again.

Not happy with this fix, should probably learn how to use Wireshark to better investigate this at some point.