### PR TITLE
Simplify CI config

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -20,4 +20,4 @@ jobs:
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v3
         with:
-          version: v1.55.2
+          version: latest

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -18,10 +18,11 @@ jobs:
 
     strategy:
       matrix:
+        # build against the two latest releases, to match golang's release
+        # policy: https://go.dev/doc/devel/release#policy
         go-version:
-        - '1.21'
-        - '1.20'
-        - '1.19'
+        - 'stable'
+        - 'oldstable'
 
     steps:
     - name: setup
@@ -32,23 +33,6 @@ jobs:
     - name: checkout
       uses: actions/checkout@v4
 
-    - id: go-cache-paths
-      run: |
-        echo "::set-output name=go-build::$(go env GOCACHE)"
-        echo "::set-output name=go-mod::$(go env GOMODCACHE)"
-
-    - name: cache build
-      uses: actions/cache@v4
-      with:
-        path: ${{ steps.go-cache-paths.outputs.go-build }}
-        key: ${{ runner.os }}-go-${{ matrix.go-version }}-build-${{ hashFiles('**/go.sum') }}
-
-    - name: cache mod
-      uses: actions/cache@v4
-      with:
-        path: ${{ steps.go-cache-paths.outputs.go-mod }}
-        key: ${{ runner.os }}-go-${{ matrix.go-version }}-mod-${{ hashFiles('**/go.sum') }}
-
     - name: test
       run: make testci
 
@@ -56,4 +40,4 @@ jobs:
       uses: codecov/codecov-action@v3
       with:
         files: ./coverage.out
-      if: ${{ matrix.go-version == '1.21' }}
+      if: ${{ matrix.go-version == 'stable' }}


### PR DESCRIPTION
Test against the two most recent stable golang versions, matching [the golang release policy](https://go.dev/doc/devel/release#policy).