### PR TITLE
Strip more ad trackers during canonicalization

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -18,6 +18,6 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: golangci-lint
-        uses: golangci/golangci-lint-action@v3
+        uses: golangci/golangci-lint-action@v6
         with:
           version: latest

--- a/canonicalizer.go
+++ b/canonicalizer.go
@@ -60,6 +60,12 @@ var (
 		`ncid`,
 		`ref`,
 
+		// Other ad trackers?
+		`ad(set)?_(name|id)`,
+		`omega_(ad|adset|utm)_.+`,
+		`campaign_id`,
+		`variant`,
+
 		// Miscellaneous garbage-looking params noticed by @mccutchen while
 		// perusing logs
 		`_r`,

--- a/canonicalizer_test.go
+++ b/canonicalizer_test.go
@@ -116,6 +116,13 @@ func TestCanonicalize(t *testing.T) {
 			given:    "https://instagram.com/McCutchen",
 			expected: "https://instagram.com/mccutchen",
 		},
+
+		// Misc live examples
+		{
+			name:     "misc other ad trackers",
+			given:    "https://cozyhoome.com/products/ultimate-battle-blaster?utm_source=facebook&utm_medium=Instagram_Feed&utm_content=ultimate-battle-blaster%282014.06.21-电动水枪-原素材-916.mp4%29美国%2806.29%29策略1-AP-AA&utm_campaign=AdTestingCompaign&ad_name=ultimate-battle-blaster%282014.06.21-电动水枪-原素材-916.mp4%29美国%2806.29%29策略1-AP-AA&adset_name=ultimate-battle-blaster%282014.06.21-电动水枪-原素材-916.mp4%29美国%2806.29%29-AP-AA+-+广告副本&omega_utm_source=facebook&omega_utm_medium=Instagram_Feed&omega_utm_content=ultimate-battle-blaster%282014.06.21-电动水枪-原素材-916.mp4%29美国%2806.29%29策略1-AP-AA&omega_utm_campaign=AdTestingCompaign&omega_ad_name=ultimate-battle-blaster%282014.06.21-电动水枪-原素材-916.mp4%29美国%2806.29%29策略1-AP-AA&omega_adset_name=ultimate-battle-blaster%282014.06.21-电动水枪-原素材-916.mp4%29美国%2806.29%29-AP-AA+-+广告副本&fbclid=PAZXh0bgNhZW0BMAABphA7q6UnxbUJXjZTj2BQEJIoQcLnESUDHN-7xKqd_GY7azNECaFfzMlgcQ_aem_JUubgFX1pzpCn7zlN9ZMFw&campaign_id=120212446259280673&ad_id=120212446259320673&variant=50129381458194",
+			expected: "https://cozyhoome.com/products/ultimate-battle-blaster",
+		},
 	}
 
 	for _, tc := range testCases {

--- a/urlresolver_test.go
+++ b/urlresolver_test.go
@@ -8,10 +8,10 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
+	"os"
 	"path/filepath"
 	"strconv"
 	"strings"
@@ -686,7 +686,7 @@ func loadTitleTestCases(t *testing.T, maxBodySize int) map[string]titleTestCase 
 
 	testCases := make(map[string]titleTestCase, len(paths))
 	for _, p := range paths {
-		b, err := ioutil.ReadFile(p)
+		b, err := os.ReadFile(p)
 		if err != nil {
 			t.Fatalf("error reading file %s: %s", p, err)
 		}


### PR DESCRIPTION
See the additional test case for a live example that inspired these updates.