### PR TITLE
feat: special handling for Sailthru email tracking URLs

### DIFF
--- a/sailthru_resolver.go
+++ b/sailthru_resolver.go
@@ -1,0 +1,29 @@
+package urlresolver
+
+import (
+	"encoding/base64"
+	"net/url"
+	"regexp"
+)
+
+// https://regex101.com/r/fVcveA/1
+var sailthruRegex = regexp.MustCompile(`(?i)^https?://[^/]+/click/\d+\.\d+/([A-Za-z0-9=]+)/.+`)
+
+func matchSailthruURL(s string) (string, bool) {
+	if matches := sailthruRegex.FindStringSubmatch(s); matches != nil {
+		return matches[1], true
+	}
+	return "", false
+}
+
+func decodeSailthruURL(encodedURL string) (string, error) {
+	b, err := base64.RawURLEncoding.DecodeString(encodedURL)
+	if err != nil {
+		return "", err
+	}
+	u, err := url.Parse(string(b))
+	if err != nil {
+		return "", err
+	}
+	return u.String(), nil
+}

--- a/sailthru_resolver_test.go
+++ b/sailthru_resolver_test.go
@@ -1,0 +1,45 @@
+package urlresolver
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestSailthruResolver(t *testing.T) {
+	t.Parallel()
+
+	testCases := map[string]struct {
+		given          string
+		wantDecodedURL string
+		wantDecodeErr  bool
+	}{
+		"live valid example": {
+			given:          "https://link.mail.bloombergbusiness.com/click/30059877.127888/aHR0cHM6Ly93d3cuYmxvb21iZXJnLmNvbS9uZXdzL2FydGljbGVzLzIwMjItMTItMjIvZmlyZWQtdHdpdHRlci1tYW5hZ2VyLXN1ZXMtb3Zlci1jYW5jZWxsYXRpb24tb2Ytc3RvY2stb3B0aW9ucz9jbXBpZD1CQkQxMjIyMjJfTU9ORVlTVFVGRiZ1dG1fbWVkaXVtPWVtYWlsJnV0bV9zb3VyY2U9bmV3c2xldHRlciZ1dG1fdGVybT0yMjEyMjImdXRtX2NhbXBhaWduPW1vbmV5c3R1ZmY/5f15b2f8375b191df5003b21B03bb0f6b",
+			wantDecodedURL: "https://www.bloomberg.com/news/articles/2022-12-22/fired-twitter-manager-sues-over-cancellation-of-stock-options?cmpid=BBD122222_MONEYSTUFF&utm_medium=email&utm_source=newsletter&utm_term=221222&utm_campaign=moneystuff",
+		},
+		"invalid base64 data": {
+			given:         "https://example.com/click/1234567890.123456/0/0",
+			wantDecodeErr: true,
+		},
+		"invalid encoded URL": {
+			given:         "https://example.com/click/1234567890.123456/aHR0cDovLyUlCg/0",
+			wantDecodeErr: true,
+		},
+	}
+	for _, tc := range testCases {
+		tc := tc
+		t.Run(tc.given, func(t *testing.T) {
+			t.Parallel()
+			encodedURL, ok := matchSailthruURL(tc.given)
+			assert.True(t, ok)
+			decodedURL, err := decodeSailthruURL(encodedURL)
+			if tc.wantDecodeErr {
+				assert.Error(t, err)
+				return
+			}
+			assert.NoError(t, err)
+			assert.Equal(t, tc.wantDecodedURL, decodedURL)
+		})
+	}
+}

--- a/urlresolver.go
+++ b/urlresolver.go
@@ -95,6 +95,17 @@ func (r *Resolver) doResolve(ctx context.Context, givenURL string) (Result, erro
 		return r.resolveTweet(ctx, tweetURL, result)
 	}
 
+	// Special case Sailthru tracked links, which include the destination URL
+	// directly in the wrapped URL itself (allowing us to skip an HTTP
+	// request).
+	if encodedURL, ok := matchSailthruURL(givenURL); ok {
+		if decodedURL, err := decodeSailthruURL(encodedURL); err == nil {
+			// pretend like we resolved the Sailthru tracking URL
+			result.IntermediateURLs = append(result.IntermediateURLs, givenURL)
+			givenURL = decodedURL
+		}
+	}
+
 	req, err := http.NewRequestWithContext(ctx, "GET", givenURL, nil)
 	if err != nil {
 		return result, err


### PR DESCRIPTION
Minor optimization to skip an HTTP request when resolving a URL generated by the Sailthru email platform, which wraps tracked URLs in a way that lets us resolve them directly.

Extracted from https://github.com/mccutchen/urlresolver/pull/19